### PR TITLE
negativity gauge meter

### DIFF
--- a/v2/app_pages/sentiment/sentiment_analysis.py
+++ b/v2/app_pages/sentiment/sentiment_analysis.py
@@ -2,16 +2,74 @@ import json
 import streamlit as st
 from v2.output.charts.sentiment_types_chart import create_sentiment_types_chart
 from v2.output.counts.sentiment_type_counts import count_sentiment_types
+from v2.output.charts.negativity_gauge_meter import *
+
+@st.cache_data
+def load_and_process_data(path: str):
+    """
+    Loads the JSON, converts time strings to seconds and returns the data
+    """
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        for comment in data:
+            comment['time_in_seconds'] = time_str_to_seconds(comment.get('time_elapsed', '0:0'))
+        
+        return data
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        st.error(f"Erro ao carregar o arquivo JSON em '{path}': {e}")
+        return []
 
 def sentiment_analysis_page(path:str = 'v2/input/oscar_comments.json'):
     """
     Returns page for sentiment types analysis.
     This function sets up the Streamlit page configuration and sidebar selection for sentiment types analysis.
     """
-    data = json.load(open(path, 'r', encoding='utf-8'))
+    data = load_and_process_data(path)
+    # Adiciona o tempo em segundos a cada comentário para facilitar a filtragem (o json nao sera modificado)
+    for comment in data:
+        comment['time_in_seconds'] = time_str_to_seconds(comment.get('time_elapsed', '0:0'))
+    
+    st.title('Sentiment Analysis using Pysentimiento')
 
-    st.title('Sentiment Analysis')
+    with st.expander("Negativity Gauge Meter", expanded=True):
+        if not data:
+            st.warning("No data available.")
+            return
 
+        # Define os limites do slider
+        min_time = data[0]['time_in_seconds']
+        max_time = data[-1]['time_in_seconds']
+
+        # Cria o slider de tempo
+        selected_seconds = st.slider(
+            label="Select the video/stream timestamp:",
+            min_value=min_time,
+            max_value=max_time,
+            value=max_time
+        )
+
+        st.info(f"**Timestamp selected:** `{seconds_to_time_str(selected_seconds)}`")
+
+        # Filtra os comentários até o tempo selecionado
+        filtered_data = [c for c in data if c['time_in_seconds'] <= selected_seconds]
+
+        # Calcula a porcentagem de negatividade
+        if not filtered_data:
+            negativity_percentage = 0.0
+        else:
+            total_comments = len(filtered_data)
+            negative_comments = sum(1 for c in filtered_data if c.get('sentiment') == 'NEG')
+            negativity_percentage = (negative_comments / total_comments) * 100 if total_comments > 0 else 0
+
+        # Cria e exibe o gauge       
+        st.plotly_chart(
+            create_negativity_gauge(negativity_percentage),
+            use_container_width=True
+        )
+
+    # Grafico de barra com porcentagens de todos sentimentos em geral
     with st.expander('Sentiment Types in General', expanded=True):
         st.plotly_chart(
             create_sentiment_types_chart(

--- a/v2/output/charts/negativity_gauge_meter.py
+++ b/v2/output/charts/negativity_gauge_meter.py
@@ -1,0 +1,33 @@
+import plotly.graph_objects as go
+from datetime import timedelta
+
+def time_str_to_seconds(time_str: str) -> int:
+    """Converts a time string 'H:M:S' or 'M:S' to seconds."""
+    parts = list(map(int, time_str.split(':')))
+    if len(parts) == 3:
+        return parts[0] * 3600 + parts[1] * 60 + parts[2]
+    elif len(parts) == 2:
+        return parts[0] * 60 + parts[1]
+    return 0
+
+def seconds_to_time_str(seconds: int) -> str:
+    """Converts seconds to a time string 'HH:MM:SS'."""
+    return str(timedelta(seconds=seconds))
+
+def create_negativity_gauge(percentage: float):
+    """Creates a gauge meter."""
+    fig = go.Figure(go.Indicator(
+        mode="gauge+number",
+        value=percentage,
+        title={'text': "Level of Negativity (%)"},
+        gauge={
+            'axis': {'range': [0, 100]},
+            'bar': {'color': "#d62728"}, # Cor vermelha para negatividade
+            'steps': [
+                {'range': [0, 50], 'color': "lightgray"},
+                {'range': [50, 75], 'color': "gray"}
+            ],
+        }
+    ))
+    fig.update_layout(height=400)
+    return fig


### PR DESCRIPTION
<h2> Modificações </h2>

 - Adição de um gauge meter para medição da porcentagem de sentimentos negativos classificados pelo modelo do pysentimiento
 
 - Adição de um slider para seleção de um timestamp específico na stream/vídeo.
 
 - Função para carregar JSON e computar valores de sentimentos agora usa cache.
 
 <h2> Imagens </h2>
 
![image](https://github.com/user-attachments/assets/5161aa37-a65d-47fd-b995-4fc7afc78065)
